### PR TITLE
Tweaked RecursionBullets and ClayCatalyst item descriptions.

### DIFF
--- a/BubbetsItems/Items/BarrierItems/ClayCatalyst.cs
+++ b/BubbetsItems/Items/BarrierItems/ClayCatalyst.cs
@@ -16,7 +16,7 @@ namespace BubbetsItems.Items.BarrierItems
 			base.MakeTokens();
 			AddToken("CLAYCATALYST_NAME","Clay Catalyst");
 			AddToken("CLAYCATALYST_DESC", "Release a " + "{0}m barrier effect ".Style(StyleEnum.Heal) + "during the Teleporter event, " + "multiplying barrier decay ".Style(StyleEnum.Heal) + "on all nearby allies for " + "{1:0%}".Style(StyleEnum.Heal) + ".");
-			AddToken("CLAYCATALYST_DESC_SIMPLE", "Release a " + "13m ".Style(StyleEnum.Heal) + "(+3m per stack) ".Style(StyleEnum.Stack) + "barrier effect ".Style(StyleEnum.Heal) + "during the Teleporter event, " + "multiplying barrier decay ".Style(StyleEnum.Heal) + "on all nearby allies for " + "80%".Style(StyleEnum.Heal) + ".");
+			AddToken("CLAYCATALYST_DESC_SIMPLE", "Release a " + "13m ".Style(StyleEnum.Heal) + "(+3m per stack) ".Style(StyleEnum.Stack) + "barrier effect ".Style(StyleEnum.Heal) + "during the Teleporter event, " + "multiplying barrier decay ".Style(StyleEnum.Heal) + "on all nearby allies for " + "80%".Style(StyleEnum.Heal) + " (-11% per stack)".Style(StyleEnum.Stack) + ".");
 			SimpleDescriptionToken = "CLAYCATALYST_DESC_SIMPLE";
 			AddToken("CLAYCATALYST_PICKUP", "Slow down barrier decay nearby the Teleporter event and 'Holdout Zones' such as the Void Fields.");
 			AddToken("CLAYCATALYST_LORE","");

--- a/BubbetsItems/Items/RecursionBullets.cs
+++ b/BubbetsItems/Items/RecursionBullets.cs
@@ -17,7 +17,7 @@ namespace BubbetsItems.Items
 			AddToken("RECURSIONBULLETS_NAME", "Recursion Bullets");
 			AddToken("RECURSIONBULLETS_PICKUP", "Attacking bosses increases attack speed." + " Corrupts all Armor-Piercing Rounds".Style(StyleEnum.Void) + ".");
 			AddToken("RECURSIONBULLETS_DESC", "Attacking bosses increases " + "attack speed ".Style(StyleEnum.Damage) + "by " + "{0:0%}".Style(StyleEnum.Damage) + ". Maximum cap of " + "{1:0%} attack speed".Style(StyleEnum.Damage) + ". " + "Corrupts all Armor-Piercing Rounds".Style(StyleEnum.Void));
-			AddToken("RECURSIONBULLETS_DESC_SIMPLE", "Attacking bosses increases " + "attack speed ".Style(StyleEnum.Damage) + "by " + "5%, ".Style(StyleEnum.Damage) + "caps at " + "10% ".Style(StyleEnum.Damage) + "(+10% per stack) ".Style(StyleEnum.Stack) + "attack speed".Style(StyleEnum.Damage) + ". " + "Corrupts all Armor-Piercing Rounds".Style(StyleEnum.Void));
+			AddToken("RECURSIONBULLETS_DESC_SIMPLE", "Attacking bosses increases " + "attack speed ".Style(StyleEnum.Damage) + "by " + "5% ".Style(StyleEnum.Damage) + ", caps at " + "10% ".Style(StyleEnum.Damage) + "(+10% per stack) ".Style(StyleEnum.Stack) + "attack speed".Style(StyleEnum.Damage) + ". " + "Corrupts all Armor-Piercing Rounds".Style(StyleEnum.Void));
 			SimpleDescriptionToken = "RECURSIONBULLETS_DESC_SIMPLE";
 			AddToken("RECURSIONBULLETS_LORE", "\"I just shot these unusual bullets that I found buried near an abandoned testing site, and they appeared back in my magazine. I stumbled across something I shouldn't have... This stuff gives off a strange aura whenever I use it. They don't get damaged either... Maybe I should've left them where I found them. For now, I'll keep them locked up in the warehouse.\"");
 		}


### PR DESCRIPTION
fixed a little formatting on recursion bullets and added another scaling function in the simple item description for clay catalyst with it's barrier decay multiplier 