### PR TITLE
NetworkedTimedBuffs: Fix for timedBuffsMap throwing errors on adding elements to new lists

### DIFF
--- a/NetworkedTimedBuffs/HarmonyPatches.cs
+++ b/NetworkedTimedBuffs/HarmonyPatches.cs
@@ -145,7 +145,8 @@ namespace NetworkedTimedBuffs
 		{
 			if (__instance.GetType() != typeof(List<CharacterBody.TimedBuff>)) return;
 			if (!NetworkServer.active) return;
-			var body = NetworkedTimedBuffsPlugin.timedBuffsMap[__instance];
+			NetworkedTimedBuffsPlugin.timedBuffsMap.TryGetValue(__instance, out var body);
+			if (body == null) return;
 			if (!body.isPlayerControlled && NetworkedTimedBuffsPlugin.onlySyncPlayers.Value) return;
 			new SyncTimedBuffAdd(body.networkIdentity.netId, item.buffIndex, item.timer).Send(NetworkDestination.Clients);
 		}
@@ -154,8 +155,9 @@ namespace NetworkedTimedBuffs
 		{
 			if (__instance.GetType() != typeof(List<CharacterBody.TimedBuff>)) return;
 			if (!NetworkServer.active) return;
-			var body = NetworkedTimedBuffsPlugin.timedBuffsMap[__instance];
-			if (!body.isPlayerControlled && NetworkedTimedBuffsPlugin.onlySyncPlayers.Value) return;
+            NetworkedTimedBuffsPlugin.timedBuffsMap.TryGetValue(__instance, out var body);
+            if (body == null) return;
+            if (!body.isPlayerControlled && NetworkedTimedBuffsPlugin.onlySyncPlayers.Value) return;
 			new SyncTimedBuffRemove(body.networkIdentity.netId, index).Send(NetworkDestination.Clients);
 		}
 	}


### PR DESCRIPTION
Currently, if you create new List<CharacterBody.TimedBuff> and add anything to it, HarmonyPatches.TimedBuffAdd will throw an error due to timedBuffsMap not having it. I added a check and did a test run, it works all the same, while no longer throwing errors.